### PR TITLE
Align local build & docs with the path-based image naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # php83
 
-[![Build Images](https://github.com/Ilyes512/php83/actions/workflows/main.yml/badge.svg)](https://github.com/Ilyes512/php83/actions/workflows/main.yml)
+[![Build Images](https://github.com/specsnl/php83/actions/workflows/main.yml/badge.svg)](https://github.com/specsnl/php83/actions/workflows/main.yml)
 
 A PHP 8.3 (FPM, Apache and FrankenPHP) based Docker base image.
 
 ## Pulling the images
 
 ```
-docker pull ghcr.io/ilyes512/php83:runtime-latest
-docker pull ghcr.io/ilyes512/php83:builder-latest
-docker pull ghcr.io/ilyes512/php83:builder_nodejs-latest
+docker pull ghcr.io/specsnl/php83:runtime-latest
+docker pull ghcr.io/specsnl/php83:builder-latest
+docker pull ghcr.io/specsnl/php83:builder_nodejs-latest
 
-docker pull ghcr.io/ilyes512/php83/apache:runtime-latest
-docker pull ghcr.io/ilyes512/php83/apache:builder-latest
-docker pull ghcr.io/ilyes512/php83/apache:builder_nodejs-latest
+docker pull ghcr.io/specsnl/php83/apache:runtime-latest
+docker pull ghcr.io/specsnl/php83/apache:builder-latest
+docker pull ghcr.io/specsnl/php83/apache:builder_nodejs-latest
 
-docker pull ghcr.io/ilyes512/php83/frankenphp:runtime-latest
-docker pull ghcr.io/ilyes512/php83/frankenphp:builder-latest
-docker pull ghcr.io/ilyes512/php83/frankenphp:builder_nodejs-latest
+docker pull ghcr.io/specsnl/php83/frankenphp:runtime-latest
+docker pull ghcr.io/specsnl/php83/frankenphp:builder-latest
+docker pull ghcr.io/specsnl/php83/frankenphp:builder_nodejs-latest
 ```
 
 The tag scheme: `{TARGET}-{VERSION}`
@@ -36,19 +36,19 @@ There are multiple targets:
 Building `runtime`-target:
 
 ```
-docker build --tag ghcr.io/ilyes512/php83:runtime-latest --file fpm/Dockerfile --target runtime .
+docker build --tag ghcr.io/specsnl/php83:runtime-latest --file fpm/Dockerfile --target runtime .
 ```
 
 Building `builder`-target:
 
 ```
-docker build --tag ghcr.io/ilyes512/php83:builder-latest --file fpm/Dockerfile --target builder .
+docker build --tag ghcr.io/specsnl/php83:builder-latest --file fpm/Dockerfile --target builder .
 ```
 
 Building `builder_nodejs`-target:
 
 ```
-docker build --tag ghcr.io/ilyes512/php83:builder_nodejs-latest --file fpm/Dockerfile --target builder_nodejs .
+docker build --tag ghcr.io/specsnl/php83:builder_nodejs-latest --file fpm/Dockerfile --target builder_nodejs .
 ```
 
 ## Task commands

--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ There are multiple targets:
 Building `runtime`-target:
 
 ```
-docker build --tag ghcr.io/specsnl/php83:runtime-latest --file fpm/Dockerfile --target runtime .
+docker build --tag ghcr.io/specsnl/php83:latest --file fpm/Dockerfile --target runtime .
 ```
 
 Building `builder`-target:
 
 ```
-docker build --tag ghcr.io/specsnl/php83:builder-latest --file fpm/Dockerfile --target builder .
+docker build --tag ghcr.io/specsnl/php83/builder:latest --file fpm/Dockerfile --target builder .
 ```
 
 Building `builder_nodejs`-target:
 
 ```
-docker build --tag ghcr.io/specsnl/php83:builder_nodejs-latest --file fpm/Dockerfile --target builder_nodejs .
+docker build --tag ghcr.io/specsnl/php83/builder_nodejs:latest --file fpm/Dockerfile --target builder_nodejs .
 ```
 
 ## Task commands

--- a/README.md
+++ b/README.md
@@ -7,23 +7,27 @@ A PHP 8.3 (FPM, Apache and FrankenPHP) based Docker base image.
 ## Pulling the images
 
 ```
-docker pull ghcr.io/specsnl/php83:runtime-latest
-docker pull ghcr.io/specsnl/php83:builder-latest
-docker pull ghcr.io/specsnl/php83:builder_nodejs-latest
+# FPM
+docker pull ghcr.io/specsnl/php83:latest
+docker pull ghcr.io/specsnl/php83/builder:latest
+docker pull ghcr.io/specsnl/php83/builder_nodejs:latest
 
-docker pull ghcr.io/specsnl/php83/apache:runtime-latest
-docker pull ghcr.io/specsnl/php83/apache:builder-latest
-docker pull ghcr.io/specsnl/php83/apache:builder_nodejs-latest
+# Apache
+docker pull ghcr.io/specsnl/php83/apache:latest
+docker pull ghcr.io/specsnl/php83/apache/builder:latest
+docker pull ghcr.io/specsnl/php83/apache/builder_nodejs:latest
 
-docker pull ghcr.io/specsnl/php83/frankenphp:runtime-latest
-docker pull ghcr.io/specsnl/php83/frankenphp:builder-latest
-docker pull ghcr.io/specsnl/php83/frankenphp:builder_nodejs-latest
+# FrankenPHP
+docker pull ghcr.io/specsnl/php83/frankenphp:latest
+docker pull ghcr.io/specsnl/php83/frankenphp/builder:latest
+docker pull ghcr.io/specsnl/php83/frankenphp/builder_nodejs:latest
 ```
 
-The tag scheme: `{TARGET}-{VERSION}`
+The image name scheme: `ghcr.io/specsnl/php83[/{VARIANT}][/{TARGET}]:{VERSION}`
 
-- **{TARGET}**: `runtime`, `builder` or `builder_nodejs`
-- **{VERSION}**: `latest` or tag i.e. `1.0.0`
+- **{VARIANT}**: omitted for FPM, otherwise `apache` or `frankenphp`
+- **{TARGET}**: omitted for `runtime`, otherwise `builder` or `builder_nodejs` (also published as `node`)
+- **{VERSION}**: `latest`, a release tag (i.e. `1.8.5`), `main` or `pr-<number>`
 
 ## Building the docker image(s)
 
@@ -57,12 +61,16 @@ Available [Task](https://taskfile.dev/#/) commands:
 
 ```
 * build:              Build all PHP Docker image targets of the FPM, Apache and FrankenPHP variants
+* generate:           Generate all Dockerfiles from Dockerfile.tmpl
+* lint:               Apply a Dockerfile linter to all Dockerfiles
 * build:apache:       Build all PHP Docker image targets of the Apache variant
 * build:fpm:          Build all PHP Docker image targets of the FPM variant
 * build:frankenphp:   Build all PHP Docker image targets of the FrankenPHP variant
+* install:hooks:      Install git hooks (pre-commit regenerates and stages Dockerfiles from template)
 * lint:apache:        Apply a Dockerfile linter (https://github.com/hadolint/hadolint)
 * lint:fpm:           Apply a Dockerfile linter (https://github.com/hadolint/hadolint)
 * lint:frankenphp:    Apply a Dockerfile linter (https://github.com/hadolint/hadolint)
+* remove:hooks:       Remove installed git hooks
 * shell:apache:       Interactive shell
 * shell:fpm:          Interactive shell
 * shell:frankenphp:   Interactive shell

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -107,10 +107,11 @@ tasks:
         msg: TARGET needs to contain the Docker TARGET [runtime, builder, builder_nodejs]
     vars:
       VERSION: '{{.VERSION | default "latest"}}'
+      TARGET_PATH: '{{if ne .TARGET "runtime"}}/{{.TARGET}}{{end}}'
     cmds:
       - docker build
         --target {{.TARGET}}
-        --tag {{.DOCKER_REPO}}/{{.DOCKER_OWNER}}/{{.DOCKER_IMAGE_NAME}}:{{.TARGET}}-{{.VERSION}}
+        --tag {{.DOCKER_REPO}}/{{.DOCKER_OWNER}}/{{.DOCKER_IMAGE_NAME}}{{.TARGET_PATH}}:{{.VERSION}}
         --file {{.DOCKER_FILE_PATH}}
         .
     requires:
@@ -196,7 +197,7 @@ tasks:
         --interactive
         --tty
         --rm
-        {{.DOCKER_REPO}}/{{.DOCKER_OWNER}}/{{.DOCKER_IMAGE_NAME}}:builder_nodejs-{{.VERSION | default "latest" }}
+        {{.DOCKER_REPO}}/{{.DOCKER_OWNER}}/{{.DOCKER_IMAGE_NAME}}/builder_nodejs:{{.VERSION | default "latest" }}
         bash
 
   shell:apache:
@@ -209,7 +210,7 @@ tasks:
         --interactive
         --tty
         --rm
-        {{.DOCKER_REPO}}/{{.DOCKER_OWNER}}/{{.DOCKER_IMAGE_NAME}}:builder_nodejs-{{.VERSION | default "latest" }}
+        {{.DOCKER_REPO}}/{{.DOCKER_OWNER}}/{{.DOCKER_IMAGE_NAME}}/builder_nodejs:{{.VERSION | default "latest" }}
         bash
 
   shell:frankenphp:
@@ -222,5 +223,5 @@ tasks:
         --interactive
         --tty
         --rm
-        {{.DOCKER_REPO}}/{{.DOCKER_OWNER}}/{{.DOCKER_IMAGE_NAME}}:builder_nodejs-{{.VERSION | default "latest" }}
+        {{.DOCKER_REPO}}/{{.DOCKER_OWNER}}/{{.DOCKER_IMAGE_NAME}}/builder_nodejs:{{.VERSION | default "latest" }}
         bash


### PR DESCRIPTION
The published images moved from target-as-tag-prefix (`php83:builder-latest`) to
target-as-path-segment (`php83/builder:latest`) naming. This updates the docs and
the local build tooling to match what CI actually pushes to GHCR.

> Note: this also catches the README up to the `specsnl` owner references that the
> other PHP image repositories already use (the badge and pull/build image names
> still pointed at `ilyes512`).

## README

- **Owner references**: `ilyes512` → `specsnl` in the badge and image names.
- **Pulling the images**: rewrote the pull commands per variant (FPM / Apache / FrankenPHP) using the new path-based names.
- **Naming scheme**: replaced the old `{TARGET}-{VERSION}` tag scheme with `ghcr.io/specsnl/php83[/{VARIANT}][/{TARGET}]:{VERSION}`, documenting the `node` alias and the `latest` / release / `main` / `pr-<number>` tags.
- **Building**: build examples now tag the path-based names.
- **Task commands**: refreshed the list to include `generate`, `lint`, `install:hooks` and `remove:hooks`.

## Taskfile

- `build:target`: introduced a `TARGET_PATH` var so `runtime` publishes at the variant root and other targets get their own path segment (`/builder`, `/builder_nodejs`).
- `shell:*`: pull `.../builder_nodejs:latest` instead of `...:builder_nodejs-latest`.